### PR TITLE
Make async-listener dependency non-optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,8 @@
   "devDependencies": {
     "tap": "~0.4.2"
   },
-  "optionalDependencies": {
-    "async-listener": "0.4.7"
-  },
   "dependencies": {
+    "async-listener": "0.4.7",
     "emitter-listener": "1.0.1"
   }
 }


### PR DESCRIPTION
The problem arrises when a dependant of CLS is installed with `--no-optional` to avoid unneeded features and then run with a version of node needing the polyfil.... :boom:

Turns out the dep isn't optional and the person installing it doesn't even know what `process.addAsyncListener` even is.
