### PR TITLE
correction in README to the example of names.bindEmitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ are doing other things with HTTP listeners:
 
 ```javascript
 http.createServer(function (req, res) {
-  writer.add(req);
-  writer.add(res);
+  writer.bindEmitter(req);
+  writer.bindEmitter(res);
 
   // do other stuff, some of which is asynchronous
 });


### PR DESCRIPTION
If i understood the doc correctly, the example should call `bindEmitter` instead of `add`