### PR TITLE
Made sure not to overwrite original error context

### DIFF
--- a/context.js
+++ b/context.js
@@ -49,7 +49,7 @@ Namespace.prototype.run = function (fn) {
     return context;
   }
   catch (exception) {
-    exception[ERROR_SYMBOL] = context;
+    if(! exception[ERROR_SYMBOL]) exception[ERROR_SYMBOL] = context;
     throw exception;
   }
   finally {
@@ -74,7 +74,7 @@ Namespace.prototype.bind = function (fn, context) {
       return fn.apply(this, arguments);
     }
     catch (exception) {
-      exception[ERROR_SYMBOL] = context;
+      if(! exception[ERROR_SYMBOL]) exception[ERROR_SYMBOL] = context;
       throw exception;
     }
     finally {


### PR DESCRIPTION
This happens in the case of uncaught errors in nested contexts (which are sometimes created by Mongoose, etc). The nested context rethrows the error in its catch block after attaching itself to the error, which is then subsequently caught by the parent context. Without my change the originating context would be overwritten on the error. 

This makes Namespace.prototype.fromException not very useful in such cases.

(Running the tests before and after applying my change had the same result, i.e. the same set of failures)