### PR TITLE
Fix interleaving of asycnhronous callbacks

### DIFF
--- a/context.js
+++ b/context.js
@@ -165,7 +165,7 @@ function create(name) {
 
   var namespace = new Namespace(name);
   namespace.id = process.addAsyncListener({
-    create : function () { return namespace.active; },
+    create : function () { return namespace.createContext(); },
     before : function (context, storage) { if (storage) namespace.enter(storage); },
     after  : function (context, storage) { if (storage) namespace.exit(storage); },
     error  : function (storage) { if (storage) namespace.exit(storage); }

--- a/test/interleave-contexts.tap.js
+++ b/test/interleave-contexts.tap.js
@@ -10,7 +10,7 @@ function cleanNamespace(name){
 }
 
 test("interleaved contexts", function (t) {
-  t.plan(3);
+  t.plan(4);
 
   t.test("interleaving with run", function (t) {
     t.plan(2);
@@ -54,5 +54,39 @@ test("interleaved contexts", function (t) {
 
     t.doesNotThrow(function () { ns.exit(ctx1); });
     t.doesNotThrow(function () { ns.exit(ctx2); });
+  });
+
+  t.test("interleave with process.nextTick()", function (t) {
+    var ns = cleanNamespace('test');
+
+    ns.run(function() {
+      ns.set('value', 0);
+
+      process.nextTick(function () {
+        t.equal(ns.get('value'), 0, "context has changed");
+        ns.set('value', 1);
+        t.equal(ns.get('value'), 1, "context has changed");
+
+        process.nextTick(function () {
+          t.equal(ns.get('value'), 1, "context has changed");
+          ns.set('value', 3);
+          t.equal(ns.get('value'), 3, "context has changed");
+        });
+      });
+
+      process.nextTick(function () {
+        t.equal(ns.get('value'), 0, "context has changed");
+        ns.set('value', 2);
+        t.equal(ns.get('value'), 2, "context has changed");
+
+        process.nextTick(function () {
+          t.equal(ns.get('value'), 2, "context has changed");
+          ns.set('value', 4);
+          t.equal(ns.get('value'), 4, "context has changed");
+
+          t.end();
+        });
+      });
+    });
   });
 });

--- a/test/nesting.tap.js
+++ b/test/nesting.tap.js
@@ -49,7 +49,7 @@ test("the example from the docs", function (t) {
         t.equal(outer.value, 1, "outer is active");
 
         process.nextTick(function () {
-          t.equal(writer.active, outer, "writer.active == outer");
+          t.equal(writer.active.value, outer.value, "writer.active.value == outer.value");
           t.equal(writer.get('value'), 1, "inner has been entered");
           writer.run(function (inner) {
             t.equal(writer.active, inner, "writer.active == inner");


### PR DESCRIPTION
- Create a new context when creating async callbacks; don't just push the current context to the stack.
- This test would work if the callbacks were wrapped with ns.run() or ns.bind(), because this method creates a new context.
- ns.bind() seems to have the same problem, but it has not been tested.
- Added a new test for this specific failure.
- Fixed an existing test which assumed contexts should not be created across async callbacks.
- Fixes #66 