### PR TITLE
`namespace.runReturn` method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+script:
+  - "npm test"
+
+language: node_js
+
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "6"
+
+sudo: false

--- a/README.md
+++ b/README.md
@@ -186,6 +186,19 @@ that take callbacks themselves) from the provided callback within the scope of
 that namespace. The new context is passed as an argument to the callback
 when it's called.
 
+### namespace.runAndReturn(callback)
+
+* return: the return value of the callback
+
+Create a new context on which values can be set or read. Run all the functions
+that are called (either directly, or indirectly through asynchronous functions
+that take callbacks themselves) from the provided callback within the scope of
+that namespace. The new context is passed as an argument to the callback
+when it's called.
+
+Same as `namespace.run()` but returns the return value of the callback rather
+than the context.
+
 ### namespace.bind(callback, [context])
 
 * return: a callback wrapped up in a context closure

--- a/context.js
+++ b/context.js
@@ -59,6 +59,14 @@ Namespace.prototype.run = function (fn) {
   }
 };
 
+Namespace.prototype.runAndReturn = function (fn) {
+  var value;
+  this.run(function (context) {
+    value = fn(context);
+  });
+  return value;
+};
+
 Namespace.prototype.bind = function (fn, context) {
   if (!context) {
     if (!this.active) {

--- a/test/run-and-return.tap.js
+++ b/test/run-and-return.tap.js
@@ -1,0 +1,40 @@
+'use strict';
+
+// stdlib
+var tap = require('tap');
+var test = tap.test;
+var EventEmitter = require('events').EventEmitter;
+
+// module under test
+var context = require('../context.js');
+
+// multiple contexts in use
+var tracer = context.createNamespace('tracer');
+
+
+test("simple tracer built on contexts", function (t) {
+  t.plan(7);
+
+  var harvester = new EventEmitter();
+
+  harvester.on('finished', function (transaction) {
+    t.ok(transaction, "transaction should have been passed in");
+    t.equal(transaction.status, 'ok', "transaction should have finished OK");
+    t.equal(Object.keys(process.namespaces).length, 1, "Should only have one namespace.");
+  });
+
+  var returnValue = {};
+
+  var returnedValue = tracer.runAndReturn(function(context) {
+    t.ok(tracer.active, "tracer should have an active context");
+    tracer.set('transaction', {status : 'ok'});
+    t.ok(tracer.get('transaction'), "can retrieve newly-set value");
+    t.equal(tracer.get('transaction').status, 'ok', "value should be correct");
+
+    harvester.emit('finished', context.transaction);
+
+    return returnValue;
+  });
+
+  t.equal(returnedValue, returnValue, "method should pass through return value of function run in scope");
+});


### PR DESCRIPTION
This PR adds a method `Namespace.prototype.runReturn`.

It's the same as `Namespace.prototype.run` except it returns the return value of the callback, rather than the context object.

Reduces boilerplate code when you need the return value of a function.

This is particularly useful when using promises. At present you need to do something like:

```js
function xxx() {
    var promise;
    ns.run( function() {
        promise = Promise.resolve();
    } );
    return promise;
}
```

This PR would reduce it to:

```js
function xxx() {
    return ns.runReturn( function() {
        return Promise.resolve();
    } );
}
```

Also makes for much cleaner code with coroutines e.g.:

```js
function* xxx() {
    yield ns.runReturn( co.wrap( function*() {
        yield Promise.resolve();
    } ) );
}
```

I'm not sure that the name `runReturn` is ideal. But I do feel this feature would be useful. I use CLS and promises and am often having to use the workaround pattern.

If you were willing in principle, I'd need to add tests. But please advise which file(s) they should go in - I couldn't work out the best place for them.