### PR TITLE
Make error context a non-enumerable property to avoid serialization errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+__testfile

--- a/context.js
+++ b/context.js
@@ -50,7 +50,12 @@ Namespace.prototype.run = function (fn) {
   }
   catch (exception) {
     if (exception) {
-      exception[ERROR_SYMBOL] = context;
+      Object.defineProperty(exception, ERROR_SYMBOL, {
+        configurable: false,
+        enumerable: false,
+        writable: false,
+        value: context
+      });
     }
     throw exception;
   }

--- a/context.js
+++ b/context.js
@@ -82,7 +82,12 @@ Namespace.prototype.bind = function (fn, context) {
     }
     catch (exception) {
       if (exception) {
-        exception[ERROR_SYMBOL] = context;
+        Object.defineProperty(exception, ERROR_SYMBOL, {
+          configurable: false,
+          enumerable: false,
+          writable: false,
+          value: context
+        });
       }
       throw exception;
     }

--- a/context.js
+++ b/context.js
@@ -49,9 +49,9 @@ Namespace.prototype.run = function (fn) {
     return context;
   }
   catch (exception) {
-    if (exception) {
+    if (exception && !exception[ERROR_SYMBOL]) {
       Object.defineProperty(exception, ERROR_SYMBOL, {
-        configurable: false,
+        configurable: true,
         enumerable: false,
         writable: false,
         value: context
@@ -81,9 +81,9 @@ Namespace.prototype.bind = function (fn, context) {
       return fn.apply(this, arguments);
     }
     catch (exception) {
-      if (exception) {
+      if (exception && !exception[ERROR_SYMBOL]) {
         Object.defineProperty(exception, ERROR_SYMBOL, {
-          configurable: false,
+          configurable: true,
           enumerable: false,
           writable: false,
           value: context


### PR DESCRIPTION
Error contexts can contain complex objects with circular references. By making the error context property non-enumerable, it's still accessible directly but won't be included automatically if someone tries to serialize the exception for logging.