### PR TITLE
Run tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+script:
+  - "npm test"
+
+language: node_js
+
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "6"
+
+sudo: false


### PR DESCRIPTION
This PR adds a `.travis.yml` file so tests are run on Travis CI on node v0.10.x, v0.12.x, v4.x.x, v6.x.x.

As per issue #69.