### PR TITLE
Make error context a non-enumerable property to avoid serialization errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+__testfile

--- a/context.js
+++ b/context.js
@@ -49,8 +49,13 @@ Namespace.prototype.run = function (fn) {
     return context;
   }
   catch (exception) {
-    if (exception) {
-      exception[ERROR_SYMBOL] = context;
+    if (exception && !exception[ERROR_SYMBOL]) {
+      Object.defineProperty(exception, ERROR_SYMBOL, {
+        configurable: true,
+        enumerable: false,
+        writable: false,
+        value: context
+      });
     }
     throw exception;
   }
@@ -76,8 +81,13 @@ Namespace.prototype.bind = function (fn, context) {
       return fn.apply(this, arguments);
     }
     catch (exception) {
-      if (exception) {
-        exception[ERROR_SYMBOL] = context;
+      if (exception && !exception[ERROR_SYMBOL]) {
+        Object.defineProperty(exception, ERROR_SYMBOL, {
+          configurable: true,
+          enumerable: false,
+          writable: false,
+          value: context
+        });
       }
       throw exception;
     }


### PR DESCRIPTION
This is a continuation of #75 to add a test.